### PR TITLE
omniauth: persist and pass down refresh token

### DIFF
--- a/lib/omniauth/strategies/oktaoauth.rb
+++ b/lib/omniauth/strategies/oktaoauth.rb
@@ -51,7 +51,8 @@ module OmniAuth
       def access_token
         ::OAuth2::AccessToken.new(client, oauth2_access_token.token, {
           :expires_in => oauth2_access_token.expires_in,
-          :expires_at => oauth2_access_token.expires_at
+          :expires_at => oauth2_access_token.expires_at,
+          :refresh_token => oauth2_access_token.refresh_token
         })
       end
 


### PR DESCRIPTION
Without this, we don't persist the refresh token after we get the response back
from Okta.