### PR TITLE
save the id_token and access_token in the omniauth hash

### DIFF
--- a/lib/omniauth/strategies/oktaoauth.rb
+++ b/lib/omniauth/strategies/oktaoauth.rb
@@ -39,7 +39,8 @@ module OmniAuth
         hash = {}
 
         hash[:raw_info] = raw_info unless skip_info?
-        hash[:id_token] = access_token.token
+        hash[:id_token] = oauth2_access_token.params["id_token"]
+        hash[:access_token] = access_token.token
         if !options[:skip_jwt] && !access_token.token.nil?
           hash[:id_info] = validated_token(access_token.token)
         end


### PR DESCRIPTION
@andrewvanbeek-okta in my work recently with okta login, I think that access_token.token is actually better stored in :access_token.  The id_token can be stored as well for the logout id_token_hint param.