### PR TITLE
Update readme auth hash provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Here's an example of an authentication hash available in the callback by accessi
 
 ```ruby
 {
-  "provider" => "okta",
+  "provider" => "oktaoauth",
   "uid" => "0000000000000001",
   "info" => {
     "name" => "John Smith",


### PR DESCRIPTION
Updates the authentication hash's provider in the readme to match the name defined in the [Oktaoauth strategy](https://github.com/andrewvanbeek-okta/omniauth-oktaoauth/blob/master/lib/omniauth/strategies/oktaoauth.rb#L12).