### PR TITLE
Add ability to set authorize params

### DIFF
--- a/lib/omniauth/strategies/oktaoauth.rb
+++ b/lib/omniauth/strategies/oktaoauth.rb
@@ -5,9 +5,7 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class Oktaoauth < OmniAuth::Strategies::OAuth2
-
-
-      DEFAULT_SCOPE = %[openid profile email].freeze
+      DEFAULT_SCOPE = %(openid profile email)
 
       option :name, 'oktaoauth'
 
@@ -15,9 +13,9 @@ module OmniAuth
       option :jwt_leeway, 60
 
       option :client_options, {
-        site:          "configure this part in client options with devise",
-        authorize_url: "configure this part in client options with devise",
-        token_url:     "configure this part in client options with devise",
+        site: 'configure this part in client options with devise',
+        authorize_url: 'configure this part in client options with devise',
+        token_url: 'configure this part in client options with devise',
         response_type: 'id_token'
       }
 
@@ -27,11 +25,11 @@ module OmniAuth
 
       info do
         {
-          name:       raw_info['name'],
-          email:      raw_info['email'],
+          name: raw_info['name'],
+          email: raw_info['email'],
           first_name: raw_info['given_name'],
-          last_name:  raw_info['family_name'],
-          image:      raw_info['picture']
+          last_name: raw_info['family_name'],
+          image: raw_info['picture']
         }
       end
 
@@ -40,28 +38,26 @@ module OmniAuth
 
         hash[:raw_info] = raw_info unless skip_info?
         hash[:id_token] = access_token.token
-        if !options[:skip_jwt] && !access_token.token.nil?
-          hash[:id_info] = validated_token(access_token.token)
-        end
+        hash[:id_info] = validated_token(access_token.token) if !options[:skip_jwt] && !access_token.token.nil?
         hash
       end
 
-      alias :oauth2_access_token :access_token
+      alias oauth2_access_token access_token
 
       def access_token
         ::OAuth2::AccessToken.new(client, oauth2_access_token.token, {
-          :expires_in => oauth2_access_token.expires_in,
-          :expires_at => oauth2_access_token.expires_at,
-          :refresh_token => oauth2_access_token.refresh_token
-        })
+                                    expires_in: oauth2_access_token.expires_in,
+                                    expires_at: oauth2_access_token.expires_at,
+                                    refresh_token: oauth2_access_token.refresh_token
+                                  })
       end
 
       def raw_info
-        if options[:auth_server_id]
-          options[:auth_server_id] = options[:auth_server_id] + "/"
-        else
-          options[:auth_server_id] = ""
-        end
+        options[:auth_server_id] = if options[:auth_server_id]
+                                     options[:auth_server_id] + '/'
+                                   else
+                                     ''
+                                   end
 
         @_raw_info ||= access_token.get('/oauth2/' + options[:auth_server_id] + 'v1/userinfo').parsed || {}
       rescue ::Errno::ETIMEDOUT
@@ -80,21 +76,30 @@ module OmniAuth
         options[:redirect_uri] || (full_host + script_name + callback_path)
       end
 
+      def authorize_params
+        auth_params = request.params['authorize_params']
+        return(super) unless auth_params
+
+        additional_params = auth_params.map do |key|
+          [key, request.params[key]]
+        end.to_h
+        super.merge(additional_params)
+      end
+
       def validated_token(token)
         JWT.decode(token,
                    nil,
                    false,
-                   verify_iss:        true,
-                   iss:               options[:issuer],
-                   verify_aud:        true,
-                   aud:               options[:audience],
-                   verify_sub:        true,
+                   verify_iss: true,
+                   iss: options[:issuer],
+                   verify_aud: true,
+                   aud: options[:audience],
+                   verify_sub: true,
                    verify_expiration: true,
                    verify_not_before: true,
-                   verify_iat:        true,
-                   verify_jti:        false,
-                   leeway:            options[:jwt_leeway]
-                   ).first
+                   verify_iat: true,
+                   verify_jti: false,
+                   leeway: options[:jwt_leeway]).first
       end
     end
   end


### PR DESCRIPTION
Hi! Thanks for gem!

It will be also usefull to setup authorize params on /authorize url
For example I want to send [idp parameter ( google, facebook etc idp )](https://developer.okta.com/docs/reference/api/oidc/#authorize)
and another non-api specific ( organization name )

With this pr, I can send any parameters in my routes:

```
get '/login/:provider', to: redirect { |params, request|
  idp = ENV["OKTA_#{params[:provider].upcase}_PROVIDER_ID"]
  org = request.query_parameters['org']

  "/auth/oktaoauth?idp=#{idp}&org=#{org}&authorize_params[]=idp&authorize_params[]=org"
}
```

So user will go to /login/google => it will redirect to /auth/oktauth?idp=val1&org=val2 => It will redirect to oauth screen with valid idp =>
In callback we can parse this params also






