### PR TITLE
Change minimum compatible version of omniauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ This strategy can both use Okta's OpenID Connect and API Access Management Flows
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'omniauth-oktaoauth'
+gem 'omniauth-oktaoauth', '~> 0.1.7'
 ```
 
 And then execute:
 ```bash
-$ bundle install
+bundle install
 ```
 
 Or install it yourself as:
 ```bash
-$ gem install omniauth-oktaoauth
+gem install omniauth-oktaoauth
 ```
 
 ### Devise

--- a/lib/omniauth-oktaoauth/version.rb
+++ b/lib/omniauth-oktaoauth/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Oktaoauth
-    VERSION = '0.1.6'
+    VERSION = '0.1.7'
   end
 end

--- a/omniauth-oktaOauth.gemspec
+++ b/omniauth-oktaOauth.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "omniauth", "~> 1.5"
+  s.add_dependency "omniauth", "~> 2.0"
   s.add_dependency "omniauth-oauth2", ">= 1.4.0", "< 2.0"
 
   s.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] QA Issue Fix
- [ ] Optimization
- [x] Documentation Update

## Description
Changes the minimum compatible version of [onmiauth](https://github.com/omniauth/omniauth). Removes the dollar sign from the beginning of some terminal commands so when they are copied using the code block they can be pasted and run easily.

### Problem
Versions of onmiauth below 2.0 had the [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284) vulnerability. When using this gem you are required to use omni auth and [omniauth-rails_csrf_protection](https://github.com/cookpad/omniauth-rails_csrf_protection) version 1 or greater. omniauth-rails_csrf_protection version 1 has a dependancy or onmiauth 2.0 but omniauth-oktaoauth has a dependency of onmiauth 1.5 or greater. This means that the vulnerability cannot be fixed by using the omniauth-rails_csrf_protection gem with omniauth-oktaoauth because of the different required dependancies of the two gems. When not using the omniauth-rails_csrf_protection gem and using onmiauth 2.0 or higher there is still an error stating that bundler cannot find a compatible version of omniauth.

### Solution
Update the omniauth-oktaoauth gem's dependancy to omniauth 2.0 or later. This means that the omniauth-oktaoauth gem will be secure and the omniauth-rails_csrf_protection gem is not needed.

## Related Issues, Tickets & Documents
N/A

### UI accessibility concerns?
N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Tests not necessary.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
No.